### PR TITLE
Table of content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,7 +1316,7 @@ Published `Phylostratigraphic Map`:
 - __E-value cutoff__: 1E-5 ([DIAMOND](https://github.com/bbuchfink/diamond); protein sequences)
 - __Sequence type__: Protein Sequences
 - __Reference data bases__: NCBI nr (protein)
-- __Splice variants__: always using the representative sequences from UniProt (under "Download one protein sequence per gene (FASTA)")
+- __Splice variants__: always using the longest isoform when available
 
 This study used [GenEra](https://github.com/josuebarrera/GenEra) for gene age inference (phylostratigraphy). The following NCBI Taxonomie-ID were used.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ This collection aims to store all published maps and furthermore, provides scrip
 
 The [Introduction to Phylotranscriptomics](https://github.com/HajkD/myTAI/blob/master/vignettes/Introduction.Rmd) Vignette introduces the integration of the following `Phylostratigraphic Maps` and `Divergence Maps` to perform custom phylotranscriptomic analyses.
 
+__Note: some of the phylostratigraphic maps are now retrievable via the R data package, [`phylomapr`](https://github.com/LotharukpongJS/phylomapr). More will be added in the near future.__
+
 ## Table of Contents
 **Animals**
 - _Homo sapiens_

--- a/README.md
+++ b/README.md
@@ -42,6 +42,110 @@ This collection aims to store all published maps and furthermore, provides scrip
 
 The [Introduction to Phylotranscriptomics](https://github.com/HajkD/myTAI/blob/master/vignettes/Introduction.Rmd) Vignette introduces the integration of the following `Phylostratigraphic Maps` and `Divergence Maps` to perform custom phylotranscriptomic analyses.
 
+## Table of Contents
+**Animals**
+- _Homo sapiens_
+  - [Tomislav Domazet-Lošo and Diethard Tautz, 2008](#tomislav-domazet-lošo-and-diethard-tautz-2008)
+  - [Tomislav Domazet-Lošo and Diethard Tautz, 2010](#tomislav-domazet-lošo-and-diethard-tautz-2010)
+  - [Rafik Neme and Diethard Tautz, 2013](#rafik-neme-and-diethard-tautz-2013)
+- _Drosophila melanogaster_
+  - [Martin Sebastijan Šestak and Tomislav Domazet-Lošo, 2015](#martin-sebastijan-šestak-and-tomislav-domazet-lošo-2015)
+  - [Hajk-Georg Drost, Alexander Gabel, Ivo Grosse, Marcel Quint, 2015](#hajk-georg-drost-alexander-gabel-ivo-grosse-marcel-quint-2015)
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Danio rerio_
+  - [Rafik Neme and Diethard Tautz, 2013](#rafik-neme-and-diethard-tautz-2013)
+  - [Martin Sebastijan Šestak and Tomislav Domazet-Lošo, 2015](#martin-sebastijan-šestak-and-tomislav-domazet-lošo-2015)
+  - [Hajk-Georg Drost, Alexander Gabel, Ivo Grosse, Marcel Quint, 2015](#hajk-georg-drost-alexander-gabel-ivo-grosse-marcel-quint-2015)
+- _Mus musculus_ (mouse)
+  - [Rafik Neme and Diethard Tautz, 2013](#rafik-neme-and-diethard-tautz-2013)
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Gasterosteus aculeatus_ (three-spined stickleback)
+  - [Rafik Neme and Diethard Tautz, 2013](#rafik-neme-and-diethard-tautz-2013)
+- _Crassostrea gigas_ (Pacific oyster)
+  - [Xu F, Domazet-Lošo T, Fan D, Dunwell TL, Li L, Fang X, Zhang G., 2016](#xu-f-domazet-lošo-t-fan-d-dunwell-tl-li-l-fang-x-zhang-g-2016)
+- _Haliotis discus_ (Pacific abalone)
+  - [Xu F, Domazet-Lošo T, Fan D, Dunwell TL, Li L, Fang X, Zhang G., 2016](#xu-f-domazet-lošo-t-fan-d-dunwell-tl-li-l-fang-x-zhang-g-2016)
+- _Perinereis aibuhitensis_ (sand worm)
+  - [Xu F, Domazet-Lošo T, Fan D, Dunwell TL, Li L, Fang X, Zhang G., 2016](#xu-f-domazet-lošo-t-fan-d-dunwell-tl-li-l-fang-x-zhang-g-2016)
+- _Caenorhabditis elegans_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Echinococcus granulosus_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Octopus vulgaris_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Capitella teleta_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Apostichopus japonicus_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Nematostella vectensis_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Trichoplax adhaerens_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Amphimedon queenslandica_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+
+**Plants**
+- _Arabidopsis thaliana_
+  - [Marcel Quint, Hajk-Georg Drost, Alexander Gabel, Kristian Karsten Ullrich, Markus Boenn, Ivo Grosse, 2012](#marcel-quint-hajk-georg-drost-alexander-gabel-kristian-karsten-ullrichmarkus-boenn-ivo-grosse-2012)
+  - [Hajk-Georg Drost, Alexander Gabel, Ivo Grosse, Marcel Quint, 2015](#hajk-georg-drost-alexander-gabel-ivo-grosse-marcel-quint-2015)
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Glycine max_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Solanum lycopersicum_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Oryza sativa_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Vanilla planifolia_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Musa acuminata_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Picea glauca_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Selaginella moellendorffii_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Physcomitrella patens_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Marchantia polymorpha_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+
+**Fungi**
+- _Coprinopsis cinerea_ (gray shag)
+  - [Xuanjin Cheng, Jerome Ho Lam Hui, Yung Yung Lee, Patrick Tik Wan Law and Hoi Shan Kwan, 2015](#xuanjin-cheng-jerome-ho-lam-hui-yung-yung-lee-patrick-tik-wan-law-and-hoi-shan-kwan-2015)
+- _Saccharomyces cerevisiae_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Schizosaccharomyces pombe_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Aspergillus niger_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Morchella conica_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Cryptococcus neoformans_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Kwoniella mangroviensis_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Agaricus bisporus_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Tremella mesenterica_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Mucor circinelloides_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Batrachochytrium dendrobatidis_
+  - [Josué Barrera-Redondo, Jaruwatana Sodai Lotharukpong, Hajk-Georg Drost & Susana M. Coelho, 2023](#josué-barrera-redondo-jaruwatana-sodai-lotharukpong-hajk-georg-drost--susana-m-coelho-2023)
+- _Rhizophagus irregularis_
+  - [Bethan F Manley, Jaruwatana S Lotharukpong, Josué Barrera-Redondo, Theo Llewellyn, Gokalp Yildirir, Jana Sperschneider, Nicolas Corradi, Uta Paszkowski, Eric A Miska, Alexandra Dallaire, 2023](#bethan-f-manley-jaruwatana-s-lotharukpong-josué-barrera-redondo-theo-llewellyn-gokalp-yildirir-jana-sperschneider-nicolas-corradi-uta-paszkowski-eric-a-miska-alexandra-dallaire-2023)
+- _Geosiphon pyriformis_
+  - [Bethan F Manley, Jaruwatana S Lotharukpong, Josué Barrera-Redondo, Theo Llewellyn, Gokalp Yildirir, Jana Sperschneider, Nicolas Corradi, Uta Paszkowski, Eric A Miska, Alexandra Dallaire, 2023](#bethan-f-manley-jaruwatana-s-lotharukpong-josué-barrera-redondo-theo-llewellyn-gokalp-yildirir-jana-sperschneider-nicolas-corradi-uta-paszkowski-eric-a-miska-alexandra-dallaire-2023)
+- _Gigaspora margarita_
+  - [Bethan F Manley, Jaruwatana S Lotharukpong, Josué Barrera-Redondo, Theo Llewellyn, Gokalp Yildirir, Jana Sperschneider, Nicolas Corradi, Uta Paszkowski, Eric A Miska, Alexandra Dallaire, 2023](#bethan-f-manley-jaruwatana-s-lotharukpong-josué-barrera-redondo-theo-llewellyn-gokalp-yildirir-jana-sperschneider-nicolas-corradi-uta-paszkowski-eric-a-miska-alexandra-dallaire-2023)
+- _Dissophora decumbens_
+  - [Bethan F Manley, Jaruwatana S Lotharukpong, Josué Barrera-Redondo, Theo Llewellyn, Gokalp Yildirir, Jana Sperschneider, Nicolas Corradi, Uta Paszkowski, Eric A Miska, Alexandra Dallaire, 2023](#bethan-f-manley-jaruwatana-s-lotharukpong-josué-barrera-redondo-theo-llewellyn-gokalp-yildirir-jana-sperschneider-nicolas-corradi-uta-paszkowski-eric-a-miska-alexandra-dallaire-2023)
+- _Mortierella elongata_
+  - [Bethan F Manley, Jaruwatana S Lotharukpong, Josué Barrera-Redondo, Theo Llewellyn, Gokalp Yildirir, Jana Sperschneider, Nicolas Corradi, Uta Paszkowski, Eric A Miska, Alexandra Dallaire, 2023](#bethan-f-manley-jaruwatana-s-lotharukpong-josué-barrera-redondo-theo-llewellyn-gokalp-yildirir-jana-sperschneider-nicolas-corradi-uta-paszkowski-eric-a-miska-alexandra-dallaire-2023)
+- _Radiomyces spectabilis_
+  - [Bethan F Manley, Jaruwatana S Lotharukpong, Josué Barrera-Redondo, Theo Llewellyn, Gokalp Yildirir, Jana Sperschneider, Nicolas Corradi, Uta Paszkowski, Eric A Miska, Alexandra Dallaire, 2023](#bethan-f-manley-jaruwatana-s-lotharukpong-josué-barrera-redondo-theo-llewellyn-gokalp-yildirir-jana-sperschneider-nicolas-corradi-uta-paszkowski-eric-a-miska-alexandra-dallaire-2023)
+- _Phycomyces blakesleeanus_
+  - [Bethan F Manley, Jaruwatana S Lotharukpong, Josué Barrera-Redondo, Theo Llewellyn, Gokalp Yildirir, Jana Sperschneider, Nicolas Corradi, Uta Paszkowski, Eric A Miska, Alexandra Dallaire, 2023](#bethan-f-manley-jaruwatana-s-lotharukpong-josué-barrera-redondo-theo-llewellyn-gokalp-yildirir-jana-sperschneider-nicolas-corradi-uta-paszkowski-eric-a-miska-alexandra-dallaire-2023)
+
 ## [Tomislav Domazet-Lošo, Josip Brajković, Diethard Tautz, 2007](http://www.sciencedirect.com/science/article/pii/S0168952507002995)
 
 __Title__: _A phylostratigraphy approach to uncover the genomic history of major adaptations in metazoan lineages_

--- a/README.md
+++ b/README.md
@@ -902,7 +902,7 @@ Published `Phylostratigraphic Map`:
   - Fungi: _Saccharomyces cerevisiae_ (strain S288C), _Schizosaccharomyces pombe_, _Aspergillus niger_ (strain CBS 513.88), _Morchella conica_, _Cryptococcus neoformans_ (var. neoformans strain JEC21), _Kwoniella mangroviensis_ (strain CBS 8507), _Agaricus bisporus_ (var. bisporus strain H97), _Tremella mesenterica_ (strain DSM 1558), _Mucor circinelloides_, _Batrachochytrium dendrobatidis_ (strain JAM81)
   - Animals: _Drosophila melanogaster_, _Caenorhabditis elegans_, _Echinococcus granulosus_, _Octopus vulgaris_, _Capitella teleta_,	_Mus musculus_,	_Apostichopus japonicus_, _Nematostella vectensis_,	_Trichoplax adhaerens_,	_Amphimedon queenslandica_
   - Plants: _Arabidopsis thaliana_, _Glycine max_, _Solanum lycopersicum_, _Oryza sativa_, _Vanilla planifolia_, _Musa acuminata_, _Picea glauca_, _Selaginella moellendorffii_, _Physcomitrella patens_, _Marchantia polymorpha_
-- __E-value cutoff__: 1E-5 ([DIAMOND](https://github.com/bbuchfink/diamond); protein sequences)
+- __E-value cutoff__: 1E-5 ([DIAMOND](https://github.com/bbuchfink/diamond); protein sequences; ultra-sensitive mode)
 - __Sequence type__: Protein Sequences
 - __Reference data bases__: NCBI nr (protein)
 - __Splice variants__: always using the representative sequences from UniProt (under "Download one protein sequence per gene (FASTA)")
@@ -1313,7 +1313,7 @@ __Title__: _A highly contiguous genome assembly reveals sources of genomic novel
 Published `Phylostratigraphic Map`:
 
 - __Organisms__: _Rhizophagus irregularis_, _Geosiphon pyriformis_, _Gigaspora margarita_, _Dissophora decumbens_, _Mortierella elongata_, _Radiomyces spectabilis_, _Phycomyces blakesleeanus_
-- __E-value cutoff__: 1E-5 ([DIAMOND](https://github.com/bbuchfink/diamond); protein sequences)
+- __E-value cutoff__: 1E-5 ([DIAMOND](https://github.com/bbuchfink/diamond); protein sequences; ultra-sensitive mode)
 - __Sequence type__: Protein Sequences
 - __Reference data bases__: NCBI nr (protein)
 - __Splice variants__: always using the longest isoform when available


### PR DESCRIPTION
To enable a quick look-up of the phylomaps, a "Table of Content" section is added. Further details are also added for published phylomaps (e.g. DIAMOND parameter). Users are also directed to [`phylomapr`](https://github.com/LotharukpongJS/phylomapr) if they want to download phylomaps using R.